### PR TITLE
Added sf::Sprite and sf::Texture overload for ImageButton

### DIFF
--- a/imgui-SFML.h
+++ b/imgui-SFML.h
@@ -1,5 +1,6 @@
 #include <SFML/System/Vector2.hpp>
 #include <SFML/Graphics/Rect.hpp>
+#include <SFML/Graphics/Color.hpp>
 
 namespace sf
 {
@@ -28,10 +29,20 @@ namespace SFML
 // custom ImGui widgets for SFML stuff
     void Image(const sf::Texture& texture);
     void Image(const sf::Texture& texture, const sf::Vector2f& size);
-    
-    void Image(const sf::Sprite& sprite);
-    void Image(const sf::Sprite& sprite, const sf::Vector2f& size); 
 
-    void Image_impl(const sf::Texture& texture, const sf::FloatRect& textureRect,
-        const sf::Vector2f& size);
+    void Image(const sf::Sprite& sprite);
+    void Image(const sf::Sprite& sprite, const sf::Vector2f& size);
+
+    bool ImageButton(const sf::Texture& texture, const int framePadding = -1,
+                     const sf::Color& bgColor = sf::Color::Transparent,
+                     const sf::Color& tintColor = sf::Color::White);
+    bool ImageButton(const sf::Texture& texture, const sf::Vector2f& size, const int framePadding = -1,
+                     const sf::Color& bgColor = sf::Color::Transparent, const sf::Color& tintColor = sf::Color::White);
+
+    bool ImageButton(const sf::Sprite& sprite, const int framePadding = -1,
+                     const sf::Color& bgColor = sf::Color::Transparent,
+                     const sf::Color& tintColor = sf::Color::White);
+    bool ImageButton(const sf::Sprite& sprite, const sf::Vector2f& size, const int framePadding = -1,
+                     const sf::Color& bgColor = sf::Color::Transparent,
+                     const sf::Color& tintColor = sf::Color::White);
 }


### PR DESCRIPTION
Maybe you are interested in my changes:
I have added sfml overloads for ImageButton (does not work otherwise for me).
Some other minor modifications, notable: If using ImGui::Image with only a sf::Sprite the the size of the sprite is taken (e.g. is uses now the scale of the sprite) I think for sprites this is more logical, for sf::Textures everything stays like it is.